### PR TITLE
Update workflow to trigger on push to main branch

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,9 @@
 name: Nigthly
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
This update modifies the GitHub Actions workflow to trigger on push events to the main branch in Digital ICID repo. This ensures that the nightly build runs daily and only triggers on changes to the main branch.